### PR TITLE
Fix for crach when there is an uneven number of attributes in route list

### DIFF
--- a/net
+++ b/net
@@ -349,7 +349,7 @@ def get_routes():
         route = {'target': target,
                  'netmask': netmask,
         }
-        for i in xrange(0, len(attrs), 2):
+        for i in xrange(0, len(attrs) & ~1, 2):
             route[attrs[i]] = attrs[i + 1]
         routes.append(route)
     return routes


### PR DESCRIPTION
When ip -4 route has a uneven number of of attributes it fails on getting routes. 

Example:
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown

"linkdown" is the issue here.
 
This broke the static option for me:
static:
  interface: eth0
  addr: 192.168.0.42/24
  gateway: 192.168.0.1
  routes:
    - default